### PR TITLE
Increased temperature limits for export of input files

### DIFF
--- a/GUI/Dialogs4/LookupDialog4.ui
+++ b/GUI/Dialogs4/LookupDialog4.ui
@@ -255,7 +255,7 @@
                 <number>2</number>
                </property>
                <property name="maximum">
-                <double>2000.000000000000000</double>
+                <double>3000.000000000000000</double>
                </property>
                <property name="value">
                 <double>25.000000000000000</double>
@@ -278,7 +278,7 @@
                 <number>2</number>
                </property>
                <property name="maximum">
-                <double>2000.000000000000000</double>
+                <double>3000.000000000000000</double>
                </property>
                <property name="value">
                 <double>25.000000000000000</double>


### PR DESCRIPTION
The Dialog "Setup for writing GEMS3K input files" has temperature limits that are too low for high-temperature applications. Therefore, with this commit, the maximum temperature is raised to 3000 degC.