### PR TITLE
Fix nan

### DIFF
--- a/GUI/Dialogs4/InitEquat.cpp
+++ b/GUI/Dialogs4/InitEquat.cpp
@@ -1016,7 +1016,13 @@ o_dtwa_ap   Wa_ap D_  -3 1  N "Input: a priori interaction parameter values (cal
         wnData.push_back(  pagesSetupData("lga", o_wd_yla)); // j "Log10 of general activity (fugacity) of Dependent Components at equilibrium state "
         // wnData.push_back(  pagesSetupData("wy", o_wd_yw)); // j "Mass concentrations of DC in multi-component phases, % (ppm in aqueous phase) "
         wnData.push_back(  pagesSetupData("gamma", o_wd_gamma)); // j "Activity coefficients of DCs (external) in practical scale (molal for aqueous species) "
+        wnData.push_back(  pagesSetupData("gamFs", o_wo_gamfs)); // j "Copy of activity coefficients Gamma before the first enter in PhaseSelection()"
         wnData.push_back(  pagesSetupData("lnGam", o_wo_lngam)); // j "Calculated  ln of internal (rational) DC activity coefficients in all phases "
+        wnData.push_back(  pagesSetupData("lnDQFt", o_wi_lndqft)); // j "new: DQF terms adding to overall activity coefficients [Ls_]"
+        wnData.push_back(  pagesSetupData("lnRcpt", o_wi_lnrcpt)); // j "new: reciprocal energy terms adding to overall activity coefficients [Ls_]"
+        wnData.push_back(  pagesSetupData("lnExet", o_wi_lnexet)); // j "new: excess energy terms adding to overall activity coefficients [Ls_]"
+        wnData.push_back(  pagesSetupData("lnCnft", o_wi_lncnft)); // j "new: configurational terms adding to overall activity (coefficients) [Ls_]"
+
         //o_w_lngmo lnGmo  D_  -3 1  j "Copy of the lnGam vector from the previous IPM iteration "
         //o_wo_lnsat lnSAT D_  -3 1  s "ln of surface activity coefficient terms for surface species "
 

--- a/Modules/Submods/ms_muload.cpp
+++ b/Modules/Submods/ms_muload.cpp
@@ -392,6 +392,11 @@ void TMulti::SolModLoad( )
                               aPH->php-> OcpN[j*pmp->LsMdc[k*3+2]+ii];
               }
            } /* jj */
+           if(gui_logger->should_log(spdlog::level::debug)) {
+               auto phase_name = char_array_to_string(pmp->SF[k]+MAXSYMB, MAXPHNAME);
+               auto new_data = to_string(pmp->MoiSN+ksn, pmp->LsMdc[k*3+1]*pmp->LsMdc[k*3+2]*pmp->L1[k]);
+               gui_logger->debug("Phase {} {} ksn {} MoiSN={} ", k, phase_name, ksn, new_data);
+           }
            // realloc memory for the collection of site fractions arrays
            if( ksf+pmp->LsMdc[k*3+1]*pmp->LsMdc[k*3+2] > aObj[ o_wo_sitfr ]->GetN()
                    || pmp->SitFr == nullptr )
@@ -407,6 +412,9 @@ void TMulti::SolModLoad( )
         switch( modT[DCE_LINK] )
         {
         case SM_UNDEF:  // no script equations were specified
+
+               /// SD 06/2026 posible not change counters and overwrite data in arrays !!!
+
                if( modT[SGM_MODE] != SM_STNGAM )
                   continue;
                pmp->LsMod[k*3] = aPH->php->ncpN;  // number of interaction parameters

--- a/Modules/Submods/ms_muload.cpp
+++ b/Modules/Submods/ms_muload.cpp
@@ -407,14 +407,18 @@ void TMulti::SolModLoad( )
                          "Error in reallocating memory for pmp->SitFr." );
            fillValue( pmp->SitFr+ksf, 0., pmp->LsMdc[k*3+1]*pmp->LsMdc[k*3+2] );
 
+           // SD 06/2026 moved here (from the end of the k-loop) so that ksn/ksf are always
+           // advanced right after MoiSN/SitFr are filled, even if the SM_UNDEF case below
+           // does an early "continue" - otherwise the next multi-site phase would reuse the
+           // same offsets and overwrite this phase's data in pmp->MoiSN / pmp->SitFr
+           ksn += pmp->LsMdc[k*3+1]*pmp->LsMdc[k*3+2]*pmp->L1[k];
+           ksf += pmp->LsMdc[k*3+1]*pmp->LsMdc[k*3+2];
+
        }
  // potentially an error - should be set in any DCE_LINK mode, also SM_UNDEF ?
         switch( modT[DCE_LINK] )
         {
         case SM_UNDEF:  // no script equations were specified
-
-               /// SD 06/2026 posible not change counters and overwrite data in arrays !!!
-
                if( modT[SGM_MODE] != SM_STNGAM )
                   continue;
                pmp->LsMod[k*3] = aPH->php->ncpN;  // number of interaction parameters
@@ -656,8 +660,6 @@ LOAD_NIDMCOEF:
         kxe += pmp->LsMod[k*3]*pmp->LsMod[k*3+1];
         kce += pmp->LsMod[k*3]*pmp->LsMod[k*3+2];
         kde += pmp->LsMdc[k*3]*pmp->L1[k];
-        ksn += pmp->LsMdc[k*3+1]*pmp->LsMdc[k*3+2]*pmp->L1[k];
-        ksf += pmp->LsMdc[k*3+1]*pmp->LsMdc[k*3+2];
 
 // new: load coefficients and parameters for TSorpMod here
 //    LOAD_SORPMCOEF:

--- a/Modules/gemsgui_version.h
+++ b/Modules/gemsgui_version.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #define GEMSGUI_VERSION "3.11.3"
-#define GEMSGUI_VERSION_HASH "68da5edd"
-#define GEMSGUI_GIT_BRANCH "check_limits"
+#define GEMSGUI_VERSION_HASH "662858a6"
+#define GEMSGUI_GIT_BRANCH "fix_nan"
 #define GEMSGUI_OSX "Linux"
 #define GEMSGUI_COMPILER_ID "GNU"
 #define GEMSGUI_COMPILER_VERSION "13.3.0"

--- a/Modules/m_compos.cpp
+++ b/Modules/m_compos.cpp
@@ -776,11 +776,150 @@ FINISH:
     return Xincr;
 }
 
+bool TCompos::check_Reduce_Conc()
+{
+    int ii;
+    std::string err_message;
 
+    std::set<char> units_quantity;
+    // build units set
+    units_quantity.insert(bcp->PcRes);
+    if(bcp->PcDC != S_OFF) {
+        for(ii=0; ii<bcp->Ld; ++ii) {
+            units_quantity.insert(bcp->CDcl[ii]);
+        }
+    }
+    if(bcp->PcAU != S_OFF) {
+        for(ii=0; ii<bcp->La; ++ii) {
+            units_quantity.insert(bcp->AUcl[ii]);
+        }
+    }
+    if(bcp->PcIC != S_OFF) {
+        for(ii=0; ii<bcp->N; ++ii) {
+            units_quantity.insert(bcp->CIcl[ii]);
+        }
+    }
+
+    // check units
+    for(auto unitp:  units_quantity) {
+        switch(unitp)    {
+        // Quantities
+        case QUAN_MKMOL: /*'Y'*/
+        case QUAN_MMOL:  /*'h'*/
+        case QUAN_MOL:   /*'M'*/
+            break;
+        case QUAN_MGRAM: /*'y'*/
+        case QUAN_GRAM:  /*'g'*/
+        case QUAN_KILO:  /*'G'*/
+            // if( DCmw > PCO_DB/18. )
+            break;
+        // Concentrations
+        case CON_MOLFR:  /*'n'*/
+        case CON_MOLPROC:/*'N'*/
+        case CON_pMOLFR: /*'f'*/
+            if(fabs(bcp->R1) <= PCO_DB) {
+                err_message = "For '" + std::to_string(unitp)
+                + "' units, need to define Ns (input total number of IC moles in this PCO).";
+                switch(vfQuestion3( window(), "Moles after conversion",
+                                    err_message+"\n What to do?",
+                                    "&Continue", "&Set default", "Cancel") ) {
+                case VF3_2: bcp->R1=1.;
+                case VF3_1: break;
+                case VF3_3: return false;
+                }
+            }
+            break;
+        // Volumes
+        case CON_VOLFR:  /*'v'*/
+        case CON_VOLPROC:/*'V'*/
+        case CON_pVOLFR: /*'u'*/
+            if(fabs(bcp->Vsys) <= PCO_DBL_MIN) {
+                err_message = "For '" + std::to_string(unitp)
+                + "' units, need to define Vs (input normalisation volume).";
+                switch(vfQuestion3( window(), "Moles after conversion",
+                                    err_message+"\n What to do?",
+                                    "&Continue", "&Set default", "Cancel") ) {
+                case VF3_2: bcp->Vsys=1.;
+                case VF3_1: break;
+                case VF3_3: return false;
+                }
+            }
+            break;
+        // Mass fractions relative to mass of the system
+        case CON_WTFR:   /*'w'*/
+        case CON_WTPROC: /*'%'*/
+        case CON_PPM:    /*'P'*/
+            if(fabs(bcp->Msys) <= PCO_DB/20.) {
+                err_message = "For '" + std::string(1, unitp)
+                + "' units, need to define Ms (input normalization mass).";
+                switch(vfQuestion3( window(), "Moles after conversion",
+                                    err_message+"\n What to do?",
+                                    "&Continue", "&Set default", "Cancel") ) {
+                case VF3_2: bcp->Msys=1.;
+                case VF3_1: break;
+                case VF3_3: return false;
+                }
+            }
+            break;
+        // Molalities
+        case CON_MOLAL:  /*'m'*/
+        case CON_MMOLAL: /*'i'*/
+        case CON_pMOLAL: /*'p'*/
+            if(fabs(bcp->Mwat) <= PCO_DB/18.) {
+                err_message = "For '" + std::to_string(unitp)
+                + "' units, need to define Mw (input mass of water-solvent).";
+                switch(vfQuestion3( window(), "Moles after conversion",
+                                    err_message+"\n What to do?",
+                                    "&Continue", "&Set default", "Cancel") ) {
+                case VF3_2: bcp->Mwat=1.;
+                case VF3_1: break;
+                case VF3_3: return false;
+                }
+            }
+            break;
+        // Molarities
+        case CON_MOLAR:  /*'L'*/
+        case CON_MMOLAR: /*'j'*/
+        case CON_pMOLAR: /*'q'*/
+        case CON_AQGPL: /*'d'*/
+        case CON_AQMGPL: /*'e'*/
+        case CON_AQMKGPL: /*'b'*/
+            if(fabs(bcp->Vaq) <= PCO_DBL_MIN) {
+                err_message = "For '" + std::to_string(unitp)
+                + "' units, need to define Vaq (input volume of aqueous solution for molarities).";
+                switch(vfQuestion3( window(), "Moles after conversion",
+                                    err_message+"\n What to do?",
+                                    "&Continue", "&Set default", "Cancel") ) {
+                case VF3_2: bcp->Vaq=1.;
+                case VF3_1: break;
+                case VF3_3: return false;
+                }
+            }
+            break;
+        // Weight concentrations */
+        case CON_AQWFR:  /*'C'*/
+        case CON_AQWPROC:/*'c'*/
+        case CON_AQPPM:  /*'a'*/
+            if(fabs(bcp->Maq) <= PCO_DB/18.) {
+                err_message = "For '" + std::to_string(unitp)
+                + "' units, need to define Maq (input mass of aqueous solution for dissolved mass concentrations).";
+                switch(vfQuestion3( window(), "Moles after conversion",
+                                    err_message+"\n What to do?",
+                                    "&Continue", "&Set default", "Cancel") ) {
+                case VF3_2: bcp->Maq=1.;
+                case VF3_1: break;
+                case VF3_3: return false;
+                }
+            }
+            break;
+        }
+    }
+
+    return true;
+}
 
 // Calculate record
-void
-TCompos::RecCalc( const char* key )
+void TCompos::RecCalc( const char* key )
 {
     bool only_one_step=true;
     int i, im,j, Ld, La, LdLa;
@@ -801,6 +940,10 @@ TCompos::RecCalc( const char* key )
     aDC->ods_link(0);
     TReacDC* aRC= dynamic_cast<TReacDC *>( aMod[RT_REACDC].get());
     aRC->ods_link(0);
+
+    if(check_Reduce_Conc()==false) {
+        return;  // Cancel command
+    }
 
     bc_work_dyn_new();  // allocate work arrays and set bcp->Nmax
 

--- a/Modules/m_compos.cpp
+++ b/Modules/m_compos.cpp
@@ -822,6 +822,11 @@ SPECIFY_C:
         C = new double[bcp->Nmax];
     fillValue( C, 0., bcp->Nmax );
 
+    // Set the default normalization to 100 g  to avoid hanging due to a user mistake.
+    if( fabs(bcp->Msys) < PCO_DBL_MIN ) {
+        bcp->Msys = 0.1;
+    }
+
     if( bcp->PcIC != S_OFF )
     { /*  Through IC */
         if( !CI )

--- a/Modules/m_compos.cpp
+++ b/Modules/m_compos.cpp
@@ -819,13 +819,12 @@ bool TCompos::check_Reduce_Conc()
         case CON_pMOLFR: /*'f'*/
             if(fabs(bcp->R1) <= PCO_DB) {
                 err_message = "For '" + std::to_string(unitp)
-                + "' units, need to define Ns (input total number of IC moles in this PCO).";
+                + "' units, need to define R1 (input total number of IC moles in this PCO).";
                 switch(vfQuestion3( window(), "Moles after conversion",
                                     err_message+"\n What to do?",
-                                    "&Continue", "&Set default", "Cancel") ) {
-                case VF3_2: bcp->R1=1.; break;
-                case VF3_1: break;
-                case VF3_3: return false;
+                                    "&Use default (1)", "Cancel", "") ) {
+                case VF3_1: bcp->R1=1.; break;
+                case VF3_2: return false;
                 }
             }
             break;
@@ -838,10 +837,9 @@ bool TCompos::check_Reduce_Conc()
                 + "' units, need to define Vs (input normalisation volume L).";
                 switch(vfQuestion3( window(), "Moles after conversion",
                                     err_message+"\n What to do?",
-                                    "&Continue", "&Set default", "Cancel") ) {
-                case VF3_2: bcp->Vsys=1.; break;
-                case VF3_1: break;
-                case VF3_3: return false;
+                                    "&Use default (1)", "Cancel", "") ) {
+                case VF3_1: bcp->Vsys=1.; break;
+                case VF3_2: return false;
                 }
             }
             break;
@@ -854,10 +852,9 @@ bool TCompos::check_Reduce_Conc()
                 + "' units, need to define Ms (input normalization mass kg).";
                 switch(vfQuestion3( window(), "Moles after conversion",
                                     err_message+"\n What to do?",
-                                    "&Continue", "&Set default", "Cancel") ) {
-                case VF3_2: bcp->Msys=1.; break;
-                case VF3_1: break;
-                case VF3_3: return false;
+                                    "&Use default (1)", "Cancel", "") ) {
+                case VF3_1: bcp->Msys=1.; break;
+                case VF3_2: return false;
                 }
             }
             break;
@@ -870,10 +867,9 @@ bool TCompos::check_Reduce_Conc()
                 + "' units, need to define Mw (input mass of water-solvent kg).";
                 switch(vfQuestion3( window(), "Moles after conversion",
                                     err_message+"\n What to do?",
-                                    "&Continue", "&Set default", "Cancel") ) {
-                case VF3_2: bcp->Mwat=1.; break;
-                case VF3_1: break;
-                case VF3_3: return false;
+                                    "&Use default (1)", "Cancel", "") ) {
+                case VF3_1: bcp->Mwat=1.; break;
+                case VF3_2: return false;
                 }
             }
             break;
@@ -889,10 +885,9 @@ bool TCompos::check_Reduce_Conc()
                 + "' units, need to define Vaq (input volume of aqueous solution for molarities L).";
                 switch(vfQuestion3( window(), "Moles after conversion",
                                     err_message+"\n What to do?",
-                                    "&Continue", "&Set default", "Cancel") ) {
-                case VF3_2: bcp->Vaq=1.; break;
-                case VF3_1: break;
-                case VF3_3: return false;
+                                    "&Use default (1)", "Cancel", "") ) {
+                case VF3_1: bcp->Vaq=1.; break;
+                case VF3_2: return false;
                 }
             }
             break;
@@ -905,10 +900,9 @@ bool TCompos::check_Reduce_Conc()
                 + "' units, need to define Maq (input mass of aqueous solution for dissolved mass concentrations kg).";
                 switch(vfQuestion3( window(), "Moles after conversion",
                                     err_message+"\n What to do?",
-                                    "&Continue", "&Set default", "Cancel") ) {
-                case VF3_2: bcp->Maq=1.; break;
-                case VF3_1: break;
-                case VF3_3: return false;
+                                    "&Use default (1)", "Cancel", "") ) {
+                case VF3_1: bcp->Maq=1.; break;
+                case VF3_2: return false;
                 }
             }
             break;

--- a/Modules/m_compos.cpp
+++ b/Modules/m_compos.cpp
@@ -823,7 +823,7 @@ bool TCompos::check_Reduce_Conc()
                 switch(vfQuestion3( window(), "Moles after conversion",
                                     err_message+"\n What to do?",
                                     "&Continue", "&Set default", "Cancel") ) {
-                case VF3_2: bcp->R1=1.;
+                case VF3_2: bcp->R1=1.; break;
                 case VF3_1: break;
                 case VF3_3: return false;
                 }
@@ -835,11 +835,11 @@ bool TCompos::check_Reduce_Conc()
         case CON_pVOLFR: /*'u'*/
             if(fabs(bcp->Vsys) <= PCO_DBL_MIN) {
                 err_message = "For '" + std::to_string(unitp)
-                + "' units, need to define Vs (input normalisation volume).";
+                + "' units, need to define Vs (input normalisation volume L).";
                 switch(vfQuestion3( window(), "Moles after conversion",
                                     err_message+"\n What to do?",
                                     "&Continue", "&Set default", "Cancel") ) {
-                case VF3_2: bcp->Vsys=1.;
+                case VF3_2: bcp->Vsys=1.; break;
                 case VF3_1: break;
                 case VF3_3: return false;
                 }
@@ -851,11 +851,11 @@ bool TCompos::check_Reduce_Conc()
         case CON_PPM:    /*'P'*/
             if(fabs(bcp->Msys) <= PCO_DB/20.) {
                 err_message = "For '" + std::string(1, unitp)
-                + "' units, need to define Ms (input normalization mass).";
+                + "' units, need to define Ms (input normalization mass kg).";
                 switch(vfQuestion3( window(), "Moles after conversion",
                                     err_message+"\n What to do?",
                                     "&Continue", "&Set default", "Cancel") ) {
-                case VF3_2: bcp->Msys=1.;
+                case VF3_2: bcp->Msys=1.; break;
                 case VF3_1: break;
                 case VF3_3: return false;
                 }
@@ -867,11 +867,11 @@ bool TCompos::check_Reduce_Conc()
         case CON_pMOLAL: /*'p'*/
             if(fabs(bcp->Mwat) <= PCO_DB/18.) {
                 err_message = "For '" + std::to_string(unitp)
-                + "' units, need to define Mw (input mass of water-solvent).";
+                + "' units, need to define Mw (input mass of water-solvent kg).";
                 switch(vfQuestion3( window(), "Moles after conversion",
                                     err_message+"\n What to do?",
                                     "&Continue", "&Set default", "Cancel") ) {
-                case VF3_2: bcp->Mwat=1.;
+                case VF3_2: bcp->Mwat=1.; break;
                 case VF3_1: break;
                 case VF3_3: return false;
                 }
@@ -886,11 +886,11 @@ bool TCompos::check_Reduce_Conc()
         case CON_AQMKGPL: /*'b'*/
             if(fabs(bcp->Vaq) <= PCO_DBL_MIN) {
                 err_message = "For '" + std::to_string(unitp)
-                + "' units, need to define Vaq (input volume of aqueous solution for molarities).";
+                + "' units, need to define Vaq (input volume of aqueous solution for molarities L).";
                 switch(vfQuestion3( window(), "Moles after conversion",
                                     err_message+"\n What to do?",
                                     "&Continue", "&Set default", "Cancel") ) {
-                case VF3_2: bcp->Vaq=1.;
+                case VF3_2: bcp->Vaq=1.; break;
                 case VF3_1: break;
                 case VF3_3: return false;
                 }
@@ -902,11 +902,11 @@ bool TCompos::check_Reduce_Conc()
         case CON_AQPPM:  /*'a'*/
             if(fabs(bcp->Maq) <= PCO_DB/18.) {
                 err_message = "For '" + std::to_string(unitp)
-                + "' units, need to define Maq (input mass of aqueous solution for dissolved mass concentrations).";
+                + "' units, need to define Maq (input mass of aqueous solution for dissolved mass concentrations kg).";
                 switch(vfQuestion3( window(), "Moles after conversion",
                                     err_message+"\n What to do?",
                                     "&Continue", "&Set default", "Cancel") ) {
-                case VF3_2: bcp->Maq=1.;
+                case VF3_2: bcp->Maq=1.; break;
                 case VF3_1: break;
                 case VF3_3: return false;
                 }
@@ -924,7 +924,7 @@ void TCompos::RecCalc( const char* key )
     bool only_one_step=true;
     int i, im,j, Ld, La, LdLa;
     short wps;
-    double MsysC = 0., R1C = 0.;
+    double MsysC, R1C;
     double Xincr, ICmw, DCmw;
     double *A;
     //char ICs[MAXRKEYLEN+10];
@@ -964,6 +964,9 @@ SPECIFY_C:
     }
 //   NormDoubleRound(bcp->ICw, bcp->Nmax, 8 );
 
+    // Reset accumulators before the retry
+    MsysC = 0.;
+    R1C = 0.;
     if( !C )
         C = new double[bcp->Nmax];
     fillValue( C, 0., bcp->Nmax );

--- a/Modules/m_compos.cpp
+++ b/Modules/m_compos.cpp
@@ -777,10 +777,12 @@ FINISH:
 }
 
 
+
 // Calculate record
 void
 TCompos::RecCalc( const char* key )
 {
+    bool only_one_step=true;
     int i, im,j, Ld, La, LdLa;
     short wps;
     double MsysC = 0., R1C = 0.;
@@ -801,6 +803,7 @@ TCompos::RecCalc( const char* key )
     aRC->ods_link(0);
 
     bc_work_dyn_new();  // allocate work arrays and set bcp->Nmax
+
 SPECIFY_C:
 
 	memset( pkey, 0, MAXRKEYLEN+9 );
@@ -821,11 +824,6 @@ SPECIFY_C:
     if( !C )
         C = new double[bcp->Nmax];
     fillValue( C, 0., bcp->Nmax );
-
-    // Set the default normalization to 100 g  to avoid hanging due to a user mistake.
-    if( fabs(bcp->Msys) < PCO_DBL_MIN ) {
-        bcp->Msys = 0.1;
-    }
 
     if( bcp->PcIC != S_OFF )
     { /*  Through IC */
@@ -954,7 +952,7 @@ IC_FOUND:
     /* Analyze control sum */
     if( fabs( bcp->R1 ) < PCO_DBL_MIN ) // 1e-12 )
         bcp->R1 = R1C;
-    if( fabs( bcp->R1 - (float)R1C ) <  PCO_DBL_EPSILON ) //   1e-8
+    if( fabs(R1C ) < PCO_DBL_MIN || fabs( bcp->R1 - (float)R1C ) <  PCO_DBL_EPSILON ) //   1e-8
 //            || fabs( R1C ) < PCO_DBL_MIN ) // 1e-15 )
         /*Xincr = 1.*/;
     else
@@ -978,7 +976,7 @@ IC_FOUND:
 
     if( fabs( bcp->Msys ) < PCO_DBL_MIN ) //  1e-12 )
         bcp->Msys = MsysC;
-    if( fabs( bcp->Msys - (float)MsysC ) < PCO_DBL_EPSILON ) //   1e-8
+    if( fabs(MsysC) < PCO_DBL_MIN ||  fabs( bcp->Msys - (float)MsysC ) < PCO_DBL_EPSILON ) //   1e-8
 //            || fabs( MsysC ) < PCO_DBL_MIN ) // 1e-15 )
         /*Xincr = 1.*/;
     else
@@ -1001,8 +999,10 @@ IC_FOUND:
     for( wps=0, i=0; i<bcp->Nmax; i++ )
         if( fabs( C[i] ) >= PCO_DBL_MIN ) // 1e-12 )
             wps++;
-    if( wps < 1 )
+    if( only_one_step && wps < 1 ) {
+        only_one_step = false;
         goto SPECIFY_C;
+    }
     bcp->N = wps;
     /* Realloc Compos back */
     bcp->C = (double *)aObj[ o_bccv]->Alloc( bcp->N, 1, D_ );

--- a/Modules/m_compos.h
+++ b/Modules/m_compos.h
@@ -100,6 +100,7 @@ protected:
     void bc_work_dyn_new();
     void bc_work_dyn_kill();
 
+    bool check_Reduce_Conc();
 public:
 
     static TCompos* pm;

--- a/gems3gui.pro
+++ b/gems3gui.pro
@@ -12,7 +12,7 @@ DEFINES += NDEBUG
 #DEFINES += NO_THERMOFUN
 #DEFINES += USE_THERMO_LOG
 #DEFINES += USE_GEMS3K_SERVER
-#!win32:!macx-clang:DEFINES += OVERFLOW_EXCEPT  #compile with nan inf exceptions
+!win32:!macx-clang:DEFINES += OVERFLOW_EXCEPT  #compile with nan inf exceptions
 
 CONFIG+=sdk_no_version_check
 CONFIG += c++2a


### PR DESCRIPTION
Added the objects gamFs, lnDQFt, lnRcpt, lnExet, and lnCnft to the lists in the 'Process' and 'GtDemo' wizards.

Detect error: possibly not changing counters and overwriting data in arrays in the TMulti::SolModLoad function


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced multicomponent activity-coefficient calculations with additional contributing term vectors for more accurate overall results.
  - Improved normalization safety by preventing near-zero divisions for both total moles and total mass.
  - Added validation for required normalization parameters, prompting to continue, apply defaults, or cancel.
  - Adjusted step-size retry behavior to attempt re-specification only once when needed.
- **Diagnostics**
  - Added optional debug logging for multi-site mixed-model phase filling, including phase details and populated data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->