### PR TITLE
allow 20 datasoruces

### DIFF
--- a/Modules/m_reacdc.cpp
+++ b/Modules/m_reacdc.cpp
@@ -452,7 +452,7 @@ AGAIN_MOD:
         rcp->name[db->FldLen(2)] = '\0';
         Nn1++;
     }
-    if( rcp->nTp < 0 || rcp->nPp < 0 || rcp->Nsd < 0 || rcp->Nsd > 8 )
+    if( rcp->nTp < 0 || rcp->nPp < 0 || rcp->Nsd < 0 || rcp->Nsd > 20 )
     {    if( vfQuestion( window(), GetName(),
            "W06RErem: Some counters (nTp, nCp, Nsd) are invalid! Remake again?" ))
             goto AGAIN_MOD;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the supported upper limit for reaction-system configuration values from 8 to 20.
  * Continued validation prevents invalid negative configuration values.
  * This allows larger valid configurations while maintaining safeguards against unsupported input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->