### PR TITLE
Fix Windows PATH in rungems3.bat

### DIFF
--- a/Resources/rungems3.bat
+++ b/Resources/rungems3.bat
@@ -1,6 +1,6 @@
 rem  Change the path to the actual location of gem-selektor executable and Resources
 cd ./Gems3-app/bin
-set PATH=%CD%
+set PATH=%PATH%;%CD%
 
 rem 1. First launch with default location of modeling projects (usually done by the installer)
 rem gem-selektor.exe -d > gems3.log

--- a/Resources/rungems3.bat
+++ b/Resources/rungems3.bat
@@ -1,13 +1,16 @@
+@echo off
+setlocal
+
 rem  Change the path to the actual location of gem-selektor executable and Resources
-cd ./Gems3-app/bin
-set PATH=%PATH%;%CD%
+cd /d "%~dp0Gems3-app\bin"
+set "PATH=%PATH%;%CD%"
 
 rem 1. First launch with default location of modeling projects (usually done by the installer)
 rem gem-selektor.exe -d > gems3.log
 
 rem 2. Normal runs in default locations (retains all settings from previous session)
-rem gem-selektor.exe  > gems3.log
-rem or 
+rem gem-selektor.exe > gems3.log
+rem or
 rem gem-selektor.exe -s . -u C:\Users\<USER>\Library\Gems3 > gems3.log
 
 rem 3. New file configuration if project subfolder(s) were added/removed to/from
@@ -17,7 +20,7 @@ rem or
 rem gem-selektor.exe -c -s <Path_to_Resources> -u G:\My_GEMS_Projects_Location\Gems3 > gems3.log
 
 rem 4. New \data\*.ini files - remake DOD and module dialog configurators
-rem Otherwise, does the same as  gems3 -c
+rem Otherwise, does the same as gems3 -c
 rem gem-selektor.exe -d -s . -u C:\Users\<USER>\Library\Gems3 > gems3.log
 
 rem 5. Add -f after gem-selektor.exe for a write access to database files in \DB.default\
@@ -25,15 +28,13 @@ rem (for developers only!)
 
 rem 6. Create on desktop a shortcut
 
-@echo off
-setlocal
 set "scriptPath=%~dp0"
 set "targetPath=%scriptPath%Gems3-app\bin\gem-selektor.exe"
 set "iconPath=%scriptPath%Gems3-app\bin\gem-selektor.ico"
 set "startMenuShortcut=%APPDATA%\Microsoft\Windows\Start Menu\Programs\gems-selektor.lnk"
 set "desktopShortcut=%USERPROFILE%\Desktop\gems-selektor.lnk"
 
-REM Check if required files exist
+rem Check if required files exist
 IF NOT EXIST "%targetPath%" (
     echo ERROR: Executable not found: "%targetPath%"
     exit /b
@@ -44,7 +45,7 @@ IF NOT EXIST "%iconPath%" (
     exit /b
 )
 
-REM Create Start Menu shortcut
+rem Create Start Menu shortcut
 echo Creating Start Menu shortcut...
 echo Set oWS = CreateObject("WScript.Shell") > CreateShortcut.vbs
 echo Set oLink = oWS.CreateShortcut("%startMenuShortcut%") >> CreateShortcut.vbs
@@ -55,7 +56,7 @@ cscript //nologo CreateShortcut.vbs
 del CreateShortcut.vbs
 echo Shortcut created successfully in Start Menu.
 
-REM Create Desktop shortcut
+rem Create Desktop shortcut
 echo Creating Desktop shortcut...
 echo Set oWS = CreateObject("WScript.Shell") > CreateShortcut.vbs
 echo strDesktop = oWS.SpecialFolders("Desktop") >> CreateShortcut.vbs


### PR DESCRIPTION
Fixes the Windows startup issue by preserving the existing `PATH` when adding the GEMS `bin` directory.

Fixes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Gems3 launcher to preserve the existing system `PATH` while adding the Gems3 tools directory.
  * Other command-line tools should remain accessible when running the launcher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->